### PR TITLE
Make ALLOWED_HOSTS configurable

### DIFF
--- a/hspc_home/settings.py
+++ b/hspc_home/settings.py
@@ -37,6 +37,13 @@ if DEBUG:
         'localhost',
     ]
 
+additional_allowed_hosts = os.environ.get("ALLOWED_HOSTS", "").split(",")
+
+for additional_host in additional_allowed_hosts:
+    if additional_host not in ALLOWED_HOSTS:
+        ALLOWED_HOSTS.append(additional_host)
+
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Can specify additional ALLOWED_HOSTS using ALLOWED_HOSTS environmental variables (as comma-separated values)