### PR TITLE
Travis builds should now be tagged with which branch they came from. …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jobs:
       - docker --version
       - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
       - docker build -t hspc-django .
-      - docker images
-      - docker tag hspc-django $DOCKER_USERNAME/hspc-django
-      - docker push $DOCKER_USERNAME/hspc-django
+      - "if [ \"$TRAVIS_BRANCH\" = master ]; then DOCKER_TAG=latest; else DOCKER_TAG=\"$TRAVIS_BRANCH\"; fi"
+      - echo "Tagging Docker image as ':$DOCKER_TAG'"
+      - docker tag hspc-django $DOCKER_USERNAME/hspc-django:${DOCKER_TAG}
+      - docker push $DOCKER_USERNAME/hspc-django:${DOCKER_TAG}


### PR DESCRIPTION
…master is mapped to :latest